### PR TITLE
feat: add prompt data source and coverage reporting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,8 +14,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Generate changelog
         uses: orhun/git-cliff-action@v2
-        with:
-          output: CHANGELOG.md
+        env:
+          OUTPUT: CHANGELOG.md
       - name: Commit and push changelog
         run: |
           git add CHANGELOG.md

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,3 +47,5 @@ jobs:
         with:
           coverage-artifact-name: code-coverage
           coverage-file-name: coverage.txt
+          skip-comment: ${{ github.event_name != 'pull_request' }}
+        continue-on-error: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,13 +6,14 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  unit_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
+          cache: false
       - name: Install dependencies
         run: go mod tidy
       - name: Format
@@ -26,4 +27,23 @@ jobs:
           args: --timeout=5m
           only-new-issues: true
       - name: Test
-        run: go test ./...
+        run: go test -coverprofile=coverage.txt ./...
+      - name: Archive coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: coverage.txt
+
+  coverage:
+    if: github.event_name == 'pull_request'
+    needs: unit_tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: fgrosse/go-coverage-report@v1.2.0
+        with:
+          coverage-artifact-name: code-coverage
+          coverage-file-name: coverage.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,11 @@
   - `go vet ./...`
   - `golangci-lint run`
   - `go test ./...`
+  - `go test -coverprofile=coverage.out ./...`
 - Ensure all checks pass before committing.
+
+## Code Coverage
+- New code should not decrease test coverage. Aim to improve coverage over time.
 
 ## Changelog Automation
 - A GitHub Actions workflow updates `CHANGELOG.md` when PRs are merged into `main`. Do not manually edit the changelog.

--- a/docs/data-sources/prompt.md
+++ b/docs/data-sources/prompt.md
@@ -1,0 +1,30 @@
+---
+# langfuse_prompt Data Source
+
+Fetches a prompt by name from Langfuse.
+
+## Example
+
+```hcl
+data "langfuse_prompt" "example" {
+  name = "my_prompt"
+}
+```
+
+Optional arguments `version` or `label` can be provided to select a specific version.
+
+## Argument Reference
+
+* `name` - (Required) Name of the prompt.
+* `version` - (Optional) Version of the prompt to retrieve.
+* `label` - (Optional) Deployment label of the prompt.
+
+## Attributes Reference
+
+* `type` - Prompt type (`chat` or `text`).
+* `prompt` - JSON encoded prompt content.
+* `config` - Configuration map of the prompt.
+* `labels` - Deployment labels for the version.
+* `tags` - Tags associated with the prompt.
+* `commit_message` - Commit message for the version.
+* `version_out` - Resolved version number.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,4 +24,5 @@ The `username` and `password` can alternatively be provided via the `LANGFUSE_US
 
 * [langfuse_project](data-sources/project.md)
 * [langfuse_project_api_keys](data-sources/project_api_keys.md)
+* [langfuse_prompt](data-sources/prompt.md)
 

--- a/langfuse/data_source_prompt.go
+++ b/langfuse/data_source_prompt.go
@@ -1,0 +1,141 @@
+package langfuse
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourcePrompt() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePromptRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"label": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"prompt": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"config": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"labels": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"commit_message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version_out": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePromptRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*apiClient)
+
+	name := d.Get("name").(string)
+
+	query := url.Values{}
+	if v, ok := d.GetOk("version"); ok {
+		query.Set("version", strconv.Itoa(v.(int)))
+	}
+	if v, ok := d.GetOk("label"); ok {
+		query.Set("label", v.(string))
+	}
+
+	path := fmt.Sprintf("/api/public/v2/prompts/%s", name)
+	if len(query) > 0 {
+		path = fmt.Sprintf("%s?%s", path, query.Encode())
+	}
+
+	var resp map[string]interface{}
+	if err := client.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if t, ok := resp["type"].(string); ok {
+		if err := d.Set("type", t); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if p, ok := resp["prompt"]; ok {
+		b, err := json.Marshal(p)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("prompt", string(b)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if cfg, ok := resp["config"].(map[string]interface{}); ok {
+		if err := d.Set("config", cfg); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if labels, ok := resp["labels"].([]interface{}); ok {
+		if err := d.Set("labels", labels); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if tags, ok := resp["tags"].([]interface{}); ok {
+		if err := d.Set("tags", tags); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if msg, ok := resp["commitMessage"].(string); ok {
+		if err := d.Set("commit_message", msg); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	version, ok := resp["version"].(float64)
+	if ok {
+		ver := int(version)
+		d.SetId(fmt.Sprintf("%s:%d", name, ver))
+		if err := d.Set("version_out", ver); err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		d.SetId(name)
+	}
+
+	return nil
+}

--- a/langfuse/provider.go
+++ b/langfuse/provider.go
@@ -57,6 +57,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"langfuse_project":          dataSourceProject(),
 			"langfuse_project_api_keys": dataSourceProjectApiKeys(),
+			"langfuse_prompt":           dataSourcePrompt(),
 		},
 	}
 


### PR DESCRIPTION
## Summary
- add new `langfuse_prompt` data source
- document the prompt data source in provider docs
- register the prompt data source in the provider
- enable Go workflow coverage reporting with PR comments
- update agent guidelines regarding test coverage
- configure Dependabot for Go module updates

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `go test -coverprofile=coverage.out ./...`


------
https://chatgpt.com/codex/tasks/task_e_68434d48801c8329ae5e58300ed34d6b