### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Potential fix for [https://github.com/d9705996/terraform-provider-langfuse/security/code-scanning/2](https://github.com/d9705996/terraform-provider-langfuse/security/code-scanning/2)

To fix the issue, we need to add an explicit `permissions` block to the `unit_tests` job. Since this job only runs tests, formats code, and uploads artifacts, it does not require write permissions. The minimal permissions required are `contents: read`, which allows the job to read the repository contents.

The changes will be made in the `.github/workflows/go.yml` file:
1. Add a `permissions` block under the `unit_tests` job.
2. Set `contents: read` as the permission for the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
