### PR TITLE
Allow host configuration via env var

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ provider "langfuse" {
 }
 ```
 
-The `username` and `password` can alternatively be provided via the `LANGFUSE_USERNAME` and `LANGFUSE_PASSWORD` environment variables.
+The `host` can also be set via the `LANGFUSE_HOST` environment variable. The `username` and `password` can alternatively be provided via the `LANGFUSE_USERNAME` and `LANGFUSE_PASSWORD` environment variables.
 
 ## Resources
 

--- a/langfuse/provider.go
+++ b/langfuse/provider.go
@@ -33,7 +33,7 @@ func Provider() *schema.Provider {
 			"host": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "https://cloud.langfuse.com",
+				DefaultFunc: schema.EnvDefaultFunc("LANGFUSE_HOST", "https://cloud.langfuse.com"),
 				Description: "Base URL for Langfuse API",
 			},
 			"username": {

--- a/langfuse/provider_test.go
+++ b/langfuse/provider_test.go
@@ -1,6 +1,8 @@
 package langfuse
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,3 +17,24 @@ var providerFactories = map[string]func() (*schema.Provider, error){
 }
 
 func testAccPreCheck(t *testing.T) {}
+
+func TestProviderHostEnvVar(t *testing.T) {
+	const h = "http://example.com"
+	if err := os.Setenv("LANGFUSE_HOST", h); err != nil {
+		t.Fatalf("set env: %v", err)
+	}
+	defer func() { _ = os.Unsetenv("LANGFUSE_HOST") }()
+
+	p := testProvider()
+	d := schema.TestResourceDataRaw(t, p.Schema, map[string]interface{}{})
+
+	raw, diags := p.ConfigureContextFunc(context.Background(), d)
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+
+	c := raw.(*apiClient)
+	if c.baseURL.String() != h {
+		t.Fatalf("expected host %q, got %q", h, c.baseURL.String())
+	}
+}


### PR DESCRIPTION
## Summary
- support `LANGFUSE_HOST` environment variable for provider host configuration
- document new environment variable
- test host configuration via environment variable

## Testing
- `golangci-lint run`
- `go test ./...`
- `go test -coverprofile=coverage.out ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843636ca99c8329a4a1e751bc98cfc2