### PR TITLE
Switch to terraform-plugin-testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.8
 require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
+	github.com/hashicorp/terraform-plugin-testing v1.13.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9T
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0 h1:NFPMacTrY/IdcIcnUB+7hsore1ZaRWU9cnB6jFoBnIM=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0/go.mod h1:QYmYnLfsosrxjCnGY1p9c7Zj6n9thnEE+7RObeYs3fA=
+github.com/hashicorp/terraform-plugin-testing v1.13.1 h1:0nhSm8lngGTggqXptU4vunFI0S2XjLAhJg3RylC5aLw=
+github.com/hashicorp/terraform-plugin-testing v1.13.1/go.mod h1:b/hl6YZLm9fjeud/3goqh/gdqhZXbRfbHMkEiY9dZwc=
 github.com/hashicorp/terraform-registry-address v0.2.5 h1:2GTftHqmUhVOeuu9CW3kwDkRe4pcBDq0uuK5VJngU1M=
 github.com/hashicorp/terraform-registry-address v0.2.5/go.mod h1:PpzXWINwB5kuVS5CA7m1+eO2f1jKb5ZDIxrOPfpnGkg=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
@@ -196,6 +198,8 @@ golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
+golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/langfuse/data_source_project_api_keys_test.go
+++ b/langfuse/data_source_project_api_keys_test.go
@@ -1,0 +1,60 @@
+package langfuse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccProjectAPIKeysDataSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		resp := map[string]interface{}{
+			"apiKeys": []map[string]interface{}{
+				{
+					"id":               "1",
+					"createdAt":        "2024-01-01T00:00:00Z",
+					"publicKey":        "pk",
+					"displaySecretKey": "disp-sk",
+					"note":             "ci",
+				},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceProjectAPIKeys(server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.langfuse_project_api_keys.test", "api_keys.0.id", "1"),
+					resource.TestCheckResourceAttr("data.langfuse_project_api_keys.test", "api_keys.0.public_key", "pk"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceProjectAPIKeys(url string) string {
+	return fmt.Sprintf(`
+provider "langfuse" {
+  host = "%s"
+}
+
+data "langfuse_project_api_keys" "test" {
+  project_id = "123"
+}
+`, url)
+}

--- a/langfuse/data_source_project_test.go
+++ b/langfuse/data_source_project_test.go
@@ -1,0 +1,56 @@
+package langfuse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccProjectDataSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		resp := map[string]interface{}{
+			"id":            "1",
+			"name":          "proj",
+			"metadata":      map[string]interface{}{"a": "b"},
+			"retentionDays": 5,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceProject(server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.langfuse_project.test", "name", "proj"),
+					resource.TestCheckResourceAttr("data.langfuse_project.test", "retention", "5"),
+					resource.TestCheckResourceAttr("data.langfuse_project.test", "metadata.a", "b"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceProject(url string) string {
+	return fmt.Sprintf(`
+provider "langfuse" {
+  host = "%s"
+}
+
+data "langfuse_project" "test" {
+  id = "1"
+}
+`, url)
+}

--- a/langfuse/data_source_prompt_test.go
+++ b/langfuse/data_source_prompt_test.go
@@ -1,0 +1,61 @@
+package langfuse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccPromptDataSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		resp := map[string]interface{}{
+			"version":       2,
+			"type":          "prompt",
+			"prompt":        map[string]interface{}{"role": "system"},
+			"config":        map[string]interface{}{"a": "b"},
+			"labels":        []string{"l1"},
+			"tags":          []string{"t1"},
+			"commitMessage": "msg",
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePrompt(server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.langfuse_prompt.test", "type", "prompt"),
+					resource.TestCheckResourceAttr("data.langfuse_prompt.test", "version_out", "2"),
+					resource.TestCheckResourceAttr("data.langfuse_prompt.test", "labels.0", "l1"),
+					resource.TestCheckResourceAttr("data.langfuse_prompt.test", "tags.0", "t1"),
+					resource.TestCheckResourceAttr("data.langfuse_prompt.test", "commit_message", "msg"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePrompt(url string) string {
+	return fmt.Sprintf(`
+provider "langfuse" {
+  host = "%s"
+}
+
+data "langfuse_prompt" "test" {
+  name = "prompt"
+}
+`, url)
+}

--- a/langfuse/resource_project_test.go
+++ b/langfuse/resource_project_test.go
@@ -7,10 +7,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccProjectResource(t *testing.T) {
+	var deleted bool
+	var updated bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPost:
@@ -28,9 +31,13 @@ func TestAccProjectResource(t *testing.T) {
 				t.Fatalf("encode response: %v", err)
 			}
 		case http.MethodGet:
+			name := "proj"
+			if updated {
+				name = "proj-upd"
+			}
 			resp := map[string]interface{}{
 				"id":            "1",
-				"name":          "proj",
+				"name":          name,
 				"metadata":      map[string]interface{}{"a": "b"},
 				"retentionDays": 5,
 			}
@@ -47,39 +54,72 @@ func TestAccProjectResource(t *testing.T) {
 			if err := json.NewEncoder(w).Encode(resp); err != nil {
 				t.Fatalf("encode response: %v", err)
 			}
+			updated = true
 		case http.MethodDelete:
+			deleted = true
 			w.WriteHeader(204)
 		}
 	}))
 	defer server.Close()
 
+	name1 := "proj"
+	name2 := "proj-upd"
+
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			if !deleted {
+				return fmt.Errorf("project not deleted")
+			}
+			return nil
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProject(server.URL),
+				Config: testAccProject(server.URL, name1),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("langfuse_project.test", "name", "proj"),
+					resource.TestCheckResourceAttr("langfuse_project.test", "name", name1),
 					resource.TestCheckResourceAttr("langfuse_project.test", "retention", "5"),
+				),
+			},
+			{
+				Config: testAccProjectUpdated(server.URL, name2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("langfuse_project.test", "name", name2),
 				),
 			},
 		},
 	})
 }
 
-func testAccProject(url string) string {
-	return fmt.Sprintf(
-		`provider "langfuse" {
+func testAccProject(url, name string) string {
+	return fmt.Sprintf(`
+provider "langfuse" {
   host = "%s"
 }
 
 resource "langfuse_project" "test" {
-  name = "proj"
+  name = "%s"
   retention = 5
   metadata = {
     a = "b"
   }
 }
-`, url)
+`, url, name)
+}
+
+func testAccProjectUpdated(url, name string) string {
+	return fmt.Sprintf(`
+provider "langfuse" {
+  host = "%s"
+}
+
+resource "langfuse_project" "test" {
+  name = "%s"
+  retention = 5
+  metadata = {
+    a = "b"
+  }
+}
+`, url, name)
 }


### PR DESCRIPTION
## Summary
- use terraform-plugin-testing for acceptance tests
- add data source tests for project, project API keys and prompts
- improve project resource test with update and destroy checks

## Testing
- `golangci-lint run`
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_684437fc43c48329b5df6eed224fe198