### PR TITLE
Fix Go version setup in workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
           cache: false
       - name: Install dependencies
         run: go mod tidy

--- a/main.go
+++ b/main.go
@@ -11,6 +11,11 @@ var (
 	commit  = ""
 )
 
+func init() {
+	// keep linter happy
+	_, _ = version, commit
+}
+
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: langfuse.Provider,


### PR DESCRIPTION
## Summary
- use go.mod to control Go version in CI
- silence linter warnings in main.go

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `go test -coverprofile=coverage.out ./...`


------
https://chatgpt.com/codex/tasks/task_e_684446264a88832982d40004d7c1a1f1