### PR TITLE
Add prompt resource

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ The `host` can also be set via the `LANGFUSE_HOST` environment variable. The `us
 
 * [langfuse_project](resources/project.md)
 * [langfuse_project_api_key](resources/project_api_key.md)
+* [langfuse_prompt](resources/prompt.md)
 
 ## Data Sources
 

--- a/docs/resources/prompt.md
+++ b/docs/resources/prompt.md
@@ -1,0 +1,22 @@
+---
+# langfuse_prompt Resource
+
+Creates and manages a prompt within a Langfuse project.
+
+## Example
+
+```hcl
+resource "langfuse_prompt" "example" {
+  project_id = "proj_123"
+  content    = "Hello, world!"
+}
+```
+
+## Argument Reference
+
+* `project_id` - (Required) ID of the project that owns the prompt.
+* `content` - (Required) Prompt content.
+
+## Attributes Reference
+
+* `id` - Prompt ID.

--- a/examples/prompt.tf
+++ b/examples/prompt.tf
@@ -1,0 +1,9 @@
+provider "langfuse" {
+  username = "${var.username}"
+  password = "${var.password}"
+}
+
+resource "langfuse_prompt" "example" {
+  project_id = "proj_123"
+  content    = "Hello, world!"
+}

--- a/langfuse/provider.go
+++ b/langfuse/provider.go
@@ -53,6 +53,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"langfuse_project":         resourceProject(),
 			"langfuse_project_api_key": resourceProjectAPIKey(),
+			"langfuse_prompt":          resourcePrompt(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"langfuse_project":          dataSourceProject(),

--- a/langfuse/resource_prompt.go
+++ b/langfuse/resource_prompt.go
@@ -1,0 +1,107 @@
+package langfuse
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type prompt struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+}
+
+func resourcePrompt() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePromptCreate,
+		ReadContext:   resourcePromptRead,
+		UpdateContext: resourcePromptUpdate,
+		DeleteContext: resourcePromptDelete,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourcePromptCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*apiClient)
+	pid := d.Get("project_id").(string)
+	body := map[string]interface{}{
+		"content": d.Get("content").(string),
+	}
+
+	var resp prompt
+	path := fmt.Sprintf("/api/public/projects/%s/prompts", pid)
+	if err := client.doRequest(ctx, http.MethodPost, path, body, &resp); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resp.ID)
+	if err := d.Set("content", resp.Content); err != nil {
+		return diag.FromErr(err)
+	}
+	return resourcePromptRead(ctx, d, meta)
+}
+
+func resourcePromptRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*apiClient)
+	pid := d.Get("project_id").(string)
+
+	var resp prompt
+	path := fmt.Sprintf("/api/public/projects/%s/prompts/%s", pid, d.Id())
+	if err := client.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		if strings.Contains(err.Error(), "404") {
+			tflog.Trace(ctx, "prompt not found, removing from state")
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("content", resp.Content); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourcePromptUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*apiClient)
+	pid := d.Get("project_id").(string)
+	body := map[string]interface{}{
+		"content": d.Get("content").(string),
+	}
+
+	var resp prompt
+	path := fmt.Sprintf("/api/public/projects/%s/prompts/%s", pid, d.Id())
+	if err := client.doRequest(ctx, http.MethodPut, path, body, &resp); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourcePromptRead(ctx, d, meta)
+}
+
+func resourcePromptDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*apiClient)
+	pid := d.Get("project_id").(string)
+	path := fmt.Sprintf("/api/public/projects/%s/prompts/%s", pid, d.Id())
+	if err := client.doRequest(ctx, http.MethodDelete, path, nil, nil); err != nil {
+		return diag.FromErr(err)
+	}
+	tflog.Trace(ctx, "deleted prompt")
+	d.SetId("")
+	return nil
+}

--- a/langfuse/resource_prompt_test.go
+++ b/langfuse/resource_prompt_test.go
@@ -1,0 +1,100 @@
+package langfuse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccPromptResource(t *testing.T) {
+	var deleted bool
+	var updated bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			var req map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			resp := map[string]interface{}{
+				"id":      "1",
+				"content": req["content"],
+			}
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Fatalf("encode response: %v", err)
+			}
+		case http.MethodGet:
+			content := "hello"
+			if updated {
+				content = "bye"
+			}
+			resp := map[string]interface{}{
+				"id":      "1",
+				"content": content,
+			}
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Fatalf("encode response: %v", err)
+			}
+		case http.MethodPut:
+			updated = true
+			var req map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			resp := map[string]interface{}{
+				"id":      "1",
+				"content": req["content"],
+			}
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Fatalf("encode response: %v", err)
+			}
+		case http.MethodDelete:
+			deleted = true
+			w.WriteHeader(204)
+		}
+	}))
+	defer server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			if !deleted {
+				return fmt.Errorf("prompt not deleted")
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrompt(server.URL, "hello"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("langfuse_prompt.test", "content", "hello"),
+				),
+			},
+			{
+				Config: testAccPrompt(server.URL, "bye"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("langfuse_prompt.test", "content", "bye"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPrompt(url, content string) string {
+	return fmt.Sprintf(`
+provider "langfuse" {
+  host = "%s"
+}
+
+resource "langfuse_prompt" "test" {
+  project_id = "123"
+  content    = "%s"
+}
+`, url, content)
+}


### PR DESCRIPTION
## Summary
- add `langfuse_prompt` resource
- document prompt resource
- register new resource in provider
- add example configuration

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `go test -coverprofile=coverage.out ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844461b6c50832996f66a160064837c