### PR TITLE
Add resource import capability

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -24,3 +24,11 @@ resource "langfuse_project" "example" {
 ## Attributes Reference
 
 * `id` - Project ID.
+
+## Import
+
+Projects can be imported using the project ID:
+
+```shell
+terraform import langfuse_project.example <project_id>
+```

--- a/docs/resources/project_api_key.md
+++ b/docs/resources/project_api_key.md
@@ -26,3 +26,11 @@ resource "langfuse_project_api_key" "key" {
 * `created_at` - Creation timestamp.
 * `expires_at` - Expiration timestamp if configured.
 * `last_used_at` - Timestamp of last usage if available.
+
+## Import
+
+Project API keys can be imported using the project ID and API key ID separated by a slash:
+
+```shell
+terraform import langfuse_project_api_key.key <project_id>/<api_key_id>
+```

--- a/docs/resources/prompt.md
+++ b/docs/resources/prompt.md
@@ -20,3 +20,11 @@ resource "langfuse_prompt" "example" {
 ## Attributes Reference
 
 * `id` - Prompt ID.
+
+## Import
+
+Prompts can be imported using `project_id` and `prompt_id` separated by a slash:
+
+```shell
+terraform import langfuse_prompt.example <project_id>/<prompt_id>
+```

--- a/langfuse/resource_project.go
+++ b/langfuse/resource_project.go
@@ -24,6 +24,9 @@ func resourceProject() *schema.Resource {
 		ReadContext:   resourceProjectRead,
 		UpdateContext: resourceProjectUpdate,
 		DeleteContext: resourceProjectDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/langfuse/resource_project_api_key.go
+++ b/langfuse/resource_project_api_key.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -38,6 +39,9 @@ func resourceProjectAPIKey() *schema.Resource {
 		CreateContext: resourceProjectAPIKeyCreate,
 		ReadContext:   resourceProjectAPIKeyRead,
 		DeleteContext: resourceProjectAPIKeyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceProjectAPIKeyImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -184,4 +188,16 @@ func resourceProjectAPIKeyDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 	d.SetId("")
 	return nil
+}
+
+func resourceProjectAPIKeyImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("unexpected format of ID (%s), expected project_id/api_key_id", d.Id())
+	}
+	if err := d.Set("project_id", parts[0]); err != nil {
+		return nil, err
+	}
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, nil
 }

--- a/langfuse/resource_prompt.go
+++ b/langfuse/resource_prompt.go
@@ -22,6 +22,9 @@ func resourcePrompt() *schema.Resource {
 		ReadContext:   resourcePromptRead,
 		UpdateContext: resourcePromptUpdate,
 		DeleteContext: resourcePromptDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePromptImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -104,4 +107,16 @@ func resourcePromptDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	tflog.Trace(ctx, "deleted prompt")
 	d.SetId("")
 	return nil
+}
+
+func resourcePromptImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("unexpected format of ID (%s), expected project_id/prompt_id", d.Id())
+	}
+	if err := d.Set("project_id", parts[0]); err != nil {
+		return nil, err
+	}
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
## Summary
- support resource import for project, project API key, and prompt resources
- document resource import syntax

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `go test -coverprofile=coverage.out ./...`


------
https://chatgpt.com/codex/tasks/task_e_68444c4abc788329955d0ccbef47d94a