### PR TITLE
Update Go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/langfuse/terraform-provider-langfuse
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.8
+toolchain go1.24.3
 
 require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0


### PR DESCRIPTION
## Summary
- upgrade go.mod to Go 1.24 and update toolchain

## Testing
- `go1.24.3 mod tidy`
- `gofmt -w $(git ls-files '*.go')`
- `go1.24.3 vet ./...`
- `golangci-lint run`
- `go1.24.3 test ./...`
- `go1.24.3 test -coverprofile=coverage.out ./...`

------
https://chatgpt.com/codex/tasks/task_e_68447f01cc708329a4cffb9133989eb9